### PR TITLE
Schema support when parsing entities -> authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ policy_set = CedarPolicy::PolicySet.new(policy)
 
 > Currently, the single policy is not supported.
 
+If your policies have an annotation that should be preferred as their policy ids, you can pass the name of that annotation with the `id_annotation:` keyword argument.
+
+```ruby
+policy = <<~POLICY
+          @id("AdminUser 1 can view any resource")
+          permit(
+            principal == AdminUser::"1",
+            action == Action::"view",
+            resource
+          );
+        POLICY
+policy_set = CedarPolicy::PolicySet.new(policy, id_annotation: :id)
+```
+
 ### Request
 
 Prepare the Entity's ID via `EntityUid` or an object with `#to_hash` method which returns a hash with `:type` and `:id` keys.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ entities = CedarPolicy::Entities.new([
 ])
 ```
 
+You can optionally pass a schema to `Entities.new`, which will allow Cedar to evaluate action groups:
+
+```ruby
+schema = CedarPolicy::Schema.new(schema_in_cedar_format)
+entities = CedarPolicy::Entities.new(entities_array, schema: schema)
+```
+
 ### Authorizer
 
 Create an `Authorizer` object and authorize the request with the policy set and entities.

--- a/ext/cedar_policy/src/entities.rs
+++ b/ext/cedar_policy/src/entities.rs
@@ -31,28 +31,20 @@ impl TryConvert for EntitiesWrapper {
                 if schema.is_nil() {
                     None
                 } else {
-                let schema = <&RSchema>::try_convert(schema)?;
-                let schema: Schema = schema.into();
-                Some(schema)
+                    let r_schema = <&RSchema>::try_convert(schema)?;
+                    let schema: Schema = r_schema.into();
+                    Some(schema)
                 }
             },
-            _ => None
+            _ => {
+                None
+            }
         };
         match value.respond_to("to_ary", false) {
             Ok(true) => {
-                // let schema = value.funcall_public("schema", ())?;
-                // let schema = <&RSchema>::try_convert(schema)?;
-                // let schema: Schema = schema.into();
                 let value: Value = value.funcall_public("to_ary", ())?;
                 let value: JsonValueWithNoDuplicateKeys = deserialize(value)?;
-                // Ok(Self(
-                //     Entities::from_json_value(value.into(), Some(&schema))
-                //         .map_err(|e| Error::new(handle.exception_arg_error(), e.to_string()))?,
-                // ))
-                let entities = match schema {
-                    Some(schema) => Entities::from_json_value(value.into(), Some(&schema)),
-                    None => Entities::from_json_value(value.into(), None)
-                };
+                let entities = Entities::from_json_value(value.into(), schema.as_ref());
                 Ok(Self(
                     entities.map_err(|e| Error::new(handle.exception_arg_error(), e.to_string()))?,
                 ))

--- a/ext/cedar_policy/src/entities.rs
+++ b/ext/cedar_policy/src/entities.rs
@@ -1,12 +1,12 @@
 use cedar_policy::ffi::JsonValueWithNoDuplicateKeys;
-use cedar_policy::Entities;
+use cedar_policy::{Entities, Schema};
 use magnus::{
     value::{Lazy, ReprValue},
     Error, Module, RClass, Ruby, TryConvert, Value,
 };
 use serde_magnus::deserialize;
 
-use crate::CEDAR_POLICY;
+use crate::{CEDAR_POLICY, schema::RSchema};
 
 static ENTITIES: Lazy<RClass> = Lazy::new(|ruby| {
     ruby.get_inner(&CEDAR_POLICY)
@@ -25,13 +25,36 @@ impl From<EntitiesWrapper> for Entities {
 impl TryConvert for EntitiesWrapper {
     fn try_convert(value: Value) -> Result<Self, Error> {
         let handle = Ruby::get_with(value);
+        let schema = match value.respond_to("schema", false) {
+            Ok(true) => {
+                let schema: Value = value.funcall_public("schema", ())?;
+                if schema.is_nil() {
+                    None
+                } else {
+                let schema = <&RSchema>::try_convert(schema)?;
+                let schema: Schema = schema.into();
+                Some(schema)
+                }
+            },
+            _ => None
+        };
         match value.respond_to("to_ary", false) {
             Ok(true) => {
+                // let schema = value.funcall_public("schema", ())?;
+                // let schema = <&RSchema>::try_convert(schema)?;
+                // let schema: Schema = schema.into();
                 let value: Value = value.funcall_public("to_ary", ())?;
                 let value: JsonValueWithNoDuplicateKeys = deserialize(value)?;
+                // Ok(Self(
+                //     Entities::from_json_value(value.into(), Some(&schema))
+                //         .map_err(|e| Error::new(handle.exception_arg_error(), e.to_string()))?,
+                // ))
+                let entities = match schema {
+                    Some(schema) => Entities::from_json_value(value.into(), Some(&schema)),
+                    None => Entities::from_json_value(value.into(), None)
+                };
                 Ok(Self(
-                    Entities::from_json_value(value.into(), None)
-                        .map_err(|e| Error::new(handle.exception_arg_error(), e.to_string()))?,
+                    entities.map_err(|e| Error::new(handle.exception_arg_error(), e.to_string()))?,
                 ))
             }
             Err(e) => Err(Error::new(handle.exception_arg_error(), e.to_string())),

--- a/ext/cedar_policy/src/lib.rs
+++ b/ext/cedar_policy/src/lib.rs
@@ -7,6 +7,7 @@ mod diagnostics;
 mod entities;
 mod entity_uid;
 mod error;
+mod policy;
 mod policy_set;
 mod schema;
 mod request;
@@ -28,6 +29,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     request::init(ruby, &module)?;
     response::init(ruby)?;
     schema::init(ruby, &module)?;
+    policy::init(ruby, &module)?;
     policy_set::init(ruby, &module)?;
 
     Ok(())

--- a/ext/cedar_policy/src/lib.rs
+++ b/ext/cedar_policy/src/lib.rs
@@ -8,6 +8,7 @@ mod entities;
 mod entity_uid;
 mod error;
 mod policy_set;
+mod schema;
 mod request;
 mod response;
 
@@ -26,6 +27,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     authorizer::init(ruby, &module)?;
     request::init(ruby, &module)?;
     response::init(ruby)?;
+    schema::init(ruby, &module)?;
     policy_set::init(ruby, &module)?;
 
     Ok(())

--- a/ext/cedar_policy/src/policy.rs
+++ b/ext/cedar_policy/src/policy.rs
@@ -1,0 +1,61 @@
+use std::{collections::HashMap};
+
+use magnus::{function, method, scan_args::{scan_args, get_kwargs}, Error, Module, Object, RModule, Ruby, Value};
+
+use cedar_policy::{Policy, PolicyId};
+
+use crate::error::PARSE_ERROR;
+
+
+#[magnus::wrap(class = "CedarPolicy::Policy")]
+pub struct RPolicy(Policy);
+
+impl RPolicy {
+    fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
+        let args = scan_args::< _, (), (), (), _, ()>(args)?;
+        let (policy_str,): (String,) = args.required;
+        let kw_args = get_kwargs::<_, (), (Option<Value>,), ()>(args.keywords, &[], &["id"])?;
+        let (policy_id,): (Option<Value>,) = kw_args.optional;
+
+        let policy_id = policy_id.map(|policy_id| PolicyId::new(policy_id.to_string()));
+        Policy::parse(policy_id, policy_str)
+            .map(|policy| Self(policy) )
+            .map_err(|err|
+                Error::new(
+                    ruby.get_inner(&PARSE_ERROR),
+                    format!("Unable to parse policy: {}", err.to_string())
+                )
+            )
+    }
+
+    fn id(&self) -> String {
+        self.0.id().to_string()
+    }
+
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    fn annotations(&self) -> HashMap<String, String> {
+        // let annotationHash = HashMap<String, Option<String>>
+        self.0.annotations().into_iter()
+            .map(|(key, value)| (String::from(key), String::from(value)))
+            .collect()
+    }
+}
+
+impl From<&Policy> for RPolicy {
+    fn from(policy: &Policy) -> Self {
+        Self(policy.clone())
+    }
+}
+
+pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("Policy", ruby.class_object())?;
+    class.define_singleton_method("new", function!(RPolicy::new, -1))?;
+    class.define_method("id", method!(RPolicy::id, 0))?;
+    class.define_method("to_s", method!(RPolicy::to_string, 0))?;
+    class.define_method("annotations", method!(RPolicy::annotations, 0))?;
+
+    Ok(())
+}

--- a/ext/cedar_policy/src/policy_set.rs
+++ b/ext/cedar_policy/src/policy_set.rs
@@ -1,21 +1,39 @@
 use std::str::FromStr;
 
-use cedar_policy::{ParseErrors, PolicySet};
-use magnus::{function, method, scan_args::scan_args, Error, Module, Object, RArray, RModule, Ruby, Value};
+use cedar_policy::{ParseErrors, PolicyId, PolicySet};
+use magnus::{function, method, scan_args::{scan_args, get_kwargs}, Error, Module, Object, RArray, RModule, Ruby, Value};
 
-use crate::error::PARSE_ERROR;
+use crate::{error::PARSE_ERROR, policy::RPolicy};
 
 #[magnus::wrap(class = "CedarPolicy::PolicySet")]
 pub struct RPolicySet(PolicySet);
 
 impl RPolicySet {
     fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
-        let args = scan_args::<(), _, (), (), (), ()>(args)?;
+        let args = scan_args::<(), _, (), (), _, ()>(args)?;
         let (policy,): (Option<String>,) = args.optional;
+        let kw_args = get_kwargs::<_, (), (Option<Value>,), ()>(args.keywords, &[], &["id_annotation"])?;
+        let (id_annotation,) = kw_args.optional;
 
         match policy {
-            Some(policy) => Self::from_str(&policy)
-                .map_err(|e| Error::new(ruby.get_inner(&PARSE_ERROR), e.to_string())),
+            Some(policy) => {
+                let policy_set = PolicySet::from_str(&policy)
+                    .map_err(|e| Error::new(ruby.get_inner(&PARSE_ERROR), e.to_string()));
+                if policy_set.is_err() || id_annotation.is_none() {
+                    policy_set.map(|ps| Self(ps) )
+                }
+                else
+                {
+                    // Attempt to rename policies by the value of the specified annotation
+                    let new_policy_set = Self::rewrite_ids_from_annotation(
+                        policy_set.unwrap(), id_annotation.unwrap().to_string()
+                    );
+                    match new_policy_set {
+                        Ok(policy_set) => Ok(Self(policy_set)),
+                        Err(err) => Err(Error::new(ruby.exception_arg_error(), err.0))
+                    }
+                }
+            },
             None => Ok(Self(PolicySet::new())),
         }
     }
@@ -25,7 +43,28 @@ impl RPolicySet {
     }
 
     fn policies(&self) -> RArray {
-        RArray::from_iter(self.0.policies().map(|policy| policy.to_string()))
+        RArray::from_iter(self.0.policies().map(|policy| RPolicy::from(policy)))
+    }
+
+    // Returns a new policy set where all of the policies that have the specified annotation_name
+    // have the value of that annotation used as their id. Any policies that don't have the annotation
+    // will  retain their original id.
+    fn rewrite_ids_from_annotation(policy_set: PolicySet, annotation_name: String) -> Result<PolicySet, PolicyError> {
+        let mut new_policy_set = PolicySet::new();
+        let policies = policy_set.policies().map(|policy|
+            match policy.annotation(&annotation_name) {
+                Some(annotation) => policy.new_id(PolicyId::new(annotation)),
+                None => policy.clone()
+            }
+        );
+        for policy in policies {
+            let policy_id = policy.id().to_string();
+            if new_policy_set.add(policy).is_err() {
+                let message = format!("failed to add policy with id {} (duplicate?)", policy_id);
+                return Err(PolicyError(message));
+            }
+        }
+        Ok(new_policy_set)
     }
 }
 
@@ -42,6 +81,10 @@ impl FromStr for RPolicySet {
         Ok(Self(PolicySet::from_str(s)?))
     }
 }
+
+// This error exists to communicate errors when renaming policies by annotation values.
+#[derive(Debug, Clone)]
+struct PolicyError(String);
 
 pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
     let class = module.define_class("PolicySet", ruby.class_object())?;

--- a/ext/cedar_policy/src/policy_set.rs
+++ b/ext/cedar_policy/src/policy_set.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use cedar_policy::{ParseErrors, PolicySet};
-use magnus::{function, method, scan_args::scan_args, Error, Module, Object, RModule, Ruby, Value};
+use magnus::{function, method, scan_args::scan_args, Error, Module, Object, RArray, RModule, Ruby, Value};
 
 use crate::error::PARSE_ERROR;
 
@@ -23,6 +23,10 @@ impl RPolicySet {
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    fn policies(&self) -> RArray {
+        RArray::from_iter(self.0.policies().map(|policy| policy.to_string()))
+    }
 }
 
 impl From<&RPolicySet> for PolicySet {
@@ -43,6 +47,7 @@ pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
     let class = module.define_class("PolicySet", ruby.class_object())?;
     class.define_singleton_method("new", function!(RPolicySet::new, -1))?;
     class.define_method("empty?", method!(RPolicySet::is_empty, 0))?;
+    class.define_method("policies", method!(RPolicySet::policies, 0))?;
 
     Ok(())
 }

--- a/ext/cedar_policy/src/schema.rs
+++ b/ext/cedar_policy/src/schema.rs
@@ -1,0 +1,83 @@
+use std::{ops::Deref, str::FromStr};
+
+use cedar_policy::{CedarSchemaError, Schema};
+use magnus::{function, scan_args::scan_args, value::ReprValue, Error, Module, Object, RModule, Ruby, TryConvert, Value};
+
+use crate::error::PARSE_ERROR;
+
+#[magnus::wrap(class = "CedarPolicy::Schema")]
+pub struct RSchema(Schema);
+
+impl RSchema {
+    fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
+        let args = scan_args::<(), _, (), (), (), ()>(args)?;
+        let (schema,): (Option<String>,) = args.optional;
+
+        match schema {
+            Some(schema) => Self::from_str(&schema)
+                .map_err(|e| Error::new(ruby.get_inner(&PARSE_ERROR), e.to_string())),
+            None => Err(Error::new(ruby.get_inner(&PARSE_ERROR), "you must supply schema contents")),
+        }
+    }
+}
+
+impl From<RSchema> for Schema {
+    fn from(schema: RSchema) -> Self {
+        schema.0.clone()
+    }
+}
+
+impl From<&RSchema> for Schema {
+    fn from(schema: &RSchema) -> Self {
+        schema.0.clone()
+    }
+}
+
+impl FromStr for RSchema {
+    type Err = CedarSchemaError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Schema::from_str(s)?))
+    }
+}
+
+// impl TryConvert for RSchema {
+//     fn try_convert(value: Value) -> Result<Self, Error> {
+//         let handle = Ruby::get_with(value);
+//         match <RSchema>::try_convert(value) {
+//             Ok(value) => Ok(value),
+//             Err(_) => Err(Error::new(handle.exception_arg_error(), "Unabled to convert Value to RSchema")),
+//         }
+//     }
+// }
+
+// impl TryConvert for RSchema {
+//     // type Error = CedarSchemaError;
+
+//     fn try_convert(value: Value) -> Result<Self, Error> {
+//         let handle = Ruby::get_with(value);
+//         let schema: Result<RSchema, Error> = if value.class() == RSchema {
+//             value.try_into()
+//         };
+//         match value.respond_to("schema", false) {
+//             Ok(true) => {
+//                 let schema: Value = value.funcall_public("schema", ())?;
+//                 let schema = match schema {}
+//             }
+//             Err(e) => Err(Error::new(handle.exception_arg_error(), e.to_string())),
+//             _ => Err(Error::new(
+//                 handle.exception_arg_error(),
+//                 format!("no implicit conversion of {} into Entities", unsafe {
+//                     value.classname()
+//                 }),
+//             ))?,
+//         }
+//     }
+// }
+
+pub fn init(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("Schema", ruby.class_object())?;
+    class.define_singleton_method("new", function!(RSchema::new, -1))?;
+
+    Ok(())
+}

--- a/lib/cedar_policy/entities.rb
+++ b/lib/cedar_policy/entities.rb
@@ -5,6 +5,10 @@ module CedarPolicy
   class Entities
     include Enumerable
 
+    # This is a hack to work around the current pathway for building the rust Entities object
+    # in TryConvert, where we can't easily pass Schema to the Entities::from_json_value fn.
+    attr_accessor :schema
+
     def initialize(entities = [])
       @entities = Set.new(entities.map do |entity|
         next entity if entity.is_a?(Entity)

--- a/lib/cedar_policy/entities.rb
+++ b/lib/cedar_policy/entities.rb
@@ -5,16 +5,20 @@ module CedarPolicy
   class Entities
     include Enumerable
 
-    # This is a hack to work around the current pathway for building the rust Entities object
-    # in TryConvert, where we can't easily pass Schema to the Entities::from_json_value fn.
+    # Include schema in Entities to enable Cedar to evaluate Action groups.
     attr_accessor :schema
 
-    def initialize(entities = [])
+    def initialize(entities = [], schema: nil)
       @entities = Set.new(entities.map do |entity|
         next entity if entity.is_a?(Entity)
 
         Entity.new(*entity.values_at(:uid, :attrs, :parents))
       end)
+
+      if schema
+        schema = Schema.new(schema) unless schema.is_a?(Schema)
+        self.schema = schema
+      end
     end
 
     def each(&block)

--- a/spec/cedar_policy/policy_spec.rb
+++ b/spec/cedar_policy/policy_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe CedarPolicy::Policy do
+  subject { CedarPolicy::Policy.new }
+
+  describe "with policy string" do
+    context "when policy has id annotation" do
+      let(:policy_str) do
+        <<~POLICY
+          @description("Happy user can see blue sky")
+          permit (
+            principal == User::"happy",
+            action,
+            resource == Photo::"blue_sky"
+          );
+        POLICY
+      end
+
+
+      describe "policy text is accessible" do
+        subject { CedarPolicy::Policy.new(policy_str) }
+        it { is_expected.to have_attributes(to_s: policy_str) }
+      end
+
+      describe "policy id is set when given" do
+        subject { CedarPolicy::Policy.new(policy_str, id: "MyPolicyId") }
+        it { is_expected.to have_attributes(id: "MyPolicyId") }
+      end
+
+      describe "policy annotations are accessible" do
+        subject { CedarPolicy::PolicySet.new(policy_str, id_annotation: :description).policies.first }
+        it { is_expected.to have_attributes(annotations: { "description" => "Happy user can see blue sky"}) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Basically, there are two steps where schema support is relevant:

1. when parsing the entities data, so that the parser knows the shape of each entity and what entities exist
2. when running an authorization check that relies on polices rules that use Action Groups (`action in ClusterActions`)

If you give the rust cedar library's Entities constructor a Cedar Schema along with the entities, it will use the schema for parsing entities data **and** augment the entities data with information about Action Groups, so that authorization checks using Action Groups will work.

The core feature added by this PR is support for including the schema when parsing entities. Because it is common to build lots of different sets of entities using the same schema, we want to be able to parse the Schema once, and then pass it to the Entities parser every time we build a batch of entities. Since entities are parsed lazily, I chose to allow setting a `schema` attribute on the `Entities` instance, and pulling that schema attribute in when parsing entities lazily.

Also included in this PR is support for choosing a policy attribute to use as the `id`, which shows up in the `diagnostics.reason` field that explains what policies applied to an authorization request. This lets you get better ids than the default "policy0" ... "policy123" sort. And I added access to the annotations themselves, as well as the actions, action groups, principals, and resources of the Schema, primarily for ease of understanding what data has been parsed into the various Cedar objects.